### PR TITLE
patch assert method in CalculatorTest class

### DIFF
--- a/src/test/java/com/openclassrooms/testing/calculator/service/CalculatorServiceTest.java
+++ b/src/test/java/com/openclassrooms/testing/calculator/service/CalculatorServiceTest.java
@@ -119,7 +119,7 @@ public class CalculatorServiceTest {
         CalculationModel responseModel = underTest.calculate(calculationModel);
 
         // Assert
-        assertThat(responseModel.getSolution(), is(equalTo(2)));
+        assertThat(responseModel.getRightArgument(), is(equalTo(2)));
     }
 
 


### PR DESCRIPTION
**What does this PR do?**
This patch proposes using '_getRightArgument()'_ instead of '_getSolution()_' in the _CalculationServiceTest_ class.

**Description of Task to be completed?**
Change '_getSolution()_ to '_getRightArgument()_'  in the _calculate_returnsAModelWithARightArgument_whenGivenADivisionCalculation()_ method of _CalculationServiceTest_ class.

**Any background context you want to provide?**

- The _getSolution()_ method is meant to return the result of dividing Dividend(leftArgument) by Divisor(rightArgument).

- Refer to the _calculate_returnsAModelWithALeftArgument_whenGivenADivisionCalculation()_ method, where the right assertThat() value was passed as argment-in this case '_getLeftArgument()_'

